### PR TITLE
UCSBSubjects DELETE

### DIFF
--- a/.github/workflows/02-frontend-03-mutation-testing.yml
+++ b/.github/workflows/02-frontend-03-mutation-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     strategy:
       matrix:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "react-test-renderer": "^17.0.2"
   },
   "scripts": {
-    "start": "env-cmd -f ../.env -e development react-scripts start",
+    "start": "BROWSER=none env-cmd -f ../.env -e development react-scripts start",
     "build": "env-cmd -f ../.env --silent react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,9 +11,11 @@ import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
-
 import StudentsIndexPage from "main/pages/Students/StudentsIndexPage";
 import StudentsCreatePage from "main/pages/Students/StudentsCreatePage";
+
+import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage";
+import UCSBSubjectsCreatePage from "main/pages/UCSBSubjects/UCSBSubjectsCreatePage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -70,6 +72,21 @@ function App() {
             <>
               <Route exact path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
               <Route exact path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
+            </>
+          )
+        }
+
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/ucsbsubjects/list" element={<UCSBSubjectsIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/ucsbsubjects/create" element={<UCSBSubjectsCreatePage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -86,6 +86,7 @@ function App() {
         {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
+              <Route exact path="/ucsbsubjects/edit/:id" element={<UCSBSubjectsCreatePage />} />
               <Route exact path="/ucsbsubjects/create" element={<UCSBSubjectsCreatePage />} />
             </>
           )

--- a/frontend/src/fixtures/ucsbSubjectsFixtures.js
+++ b/frontend/src/fixtures/ucsbSubjectsFixtures.js
@@ -1,0 +1,25 @@
+const subjectFixtures = {
+    twoSubjects: [
+        {
+            "id": 1,
+            "subjectCode": "1A",
+            "subjectTranslation": "1B",
+            "deptCode": "1C",
+            "collegeCode": "1D",
+            "relatedDeptCode": "1E",
+            "inactive": "true"
+        },
+        {
+            "id": 2,
+            "subjectCode": "2A",
+            "subjectTranslation": "2B",
+            "deptCode": "2C",
+            "collegeCode": "2D",
+            "relatedDeptCode": "2E",
+            "inactive": "false"
+        },
+    ]
+};
+
+
+export { subjectFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -94,6 +94,21 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
             </Nav>
 
+            <Nav className="mr-auto">
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="UCSBSubjects" id="appnavbar-ucsbsubjects-dropdown" data-testid="appnavbar-ucsbsubjects-dropdown" >
+                    <NavDropdown.Item href="/ucsbsubjects/list" data-testid="appnavbar-ucsbsubjects-list">List</NavDropdown.Item>
+                    {
+                      hasRole(currentUser, "ROLE_ADMIN") && (
+                        <NavDropdown.Item href="/ucsbsubjects/create" data-testid="appnavbar-ucsbsubjects-create">Create</NavDropdown.Item>
+                      )
+                    }
+                  </NavDropdown>
+                )
+              }
+            </Nav>
+
             <Nav className="ml-auto">
               {
                 currentUser && currentUser.loggedIn ? (

--- a/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
+++ b/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
@@ -2,7 +2,7 @@ import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 // import { toast } from "react-toastify";
 import { useBackendMutation } from "main/utils/useBackend";
-import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBSubjectUtils"
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 

--- a/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
+++ b/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
@@ -53,8 +53,9 @@ export default function UCSBSubjectsTable({ subjects, currentUser }) {
             accessor: 'relatedDeptCode',
         },
         {
+            id: 'inactive',
             Header: 'Inactive',
-            accessor: 'inactive',
+            accessor: i => i.inactive.toString()
         },
     ];
 

--- a/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
+++ b/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
@@ -1,0 +1,76 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+// import { toast } from "react-toastify";
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function UCSBSubjectsTable({ subjects, currentUser }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/ucsbsubjects/edit/${cell.row.values.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/UCSBSubjects/all"]
+    );
+    // Stryker enable all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+
+    const columns = [
+        {
+            Header: 'ID',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Subject Code',
+            accessor: 'subjectCode',
+        },
+        {
+            Header: 'Subject Translation',
+            accessor: 'subjectTranslation',
+        },
+        {
+            Header: 'Department Code',
+            accessor: 'deptCode',
+        },
+        {
+            Header: 'College Code',
+            accessor: 'collegeCode',
+        },
+        {
+            Header: 'Related Department Code',
+            accessor: 'relatedDeptCode',
+        },
+        {
+            Header: 'Inactive',
+            accessor: 'inactive',
+        },
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "UCSBSubjectsTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "UCSBSubjectsTable"));
+    } 
+
+    // Stryker disable ArrayDeclaration : [columns] and [subjects] are performance optimization; mutation preserves correctness
+    const memoizedColumns = React.useMemo(() => columns, [columns]);
+    const memoizedUCSBSubjects = React.useMemo(() => subjects, [subjects]);
+    // Stryker enable ArrayDeclaration
+
+    return <OurTable
+        data={memoizedUCSBSubjects}
+        columns={memoizedColumns}
+        testid={"UCSBSubjectsTable"}
+    />;
+};

--- a/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsCreatePage.js
+++ b/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsCreatePage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBSubjectsCreatePage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New UCSB Subject</h1>
+        <p>
+          This is where the create page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsIndexPage.js
+++ b/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsIndexPage.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+// import StudentsTable from 'main/components/Students/StudentsTable';
+
+export default function UCSBSubjectsIndexPage() {
+
+  // const { data: students, error: _error, status: _status } =
+  //   useBackend(
+  //     // Stryker disable next-line all : don't test internal caching of React Query
+  //     ["/api/UCSBSubjects/all"],
+  //     { method: "GET", url: "/api/UCSBSubjects/all" },
+  //     []
+  //   );
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>UCSBSubjects</h1>
+        <p>[PLACEHOLDER]</p>
+        {/* <StudentsTable students={students} currentUser={currentUser} /> */}
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsIndexPage.js
+++ b/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsIndexPage.js
@@ -2,24 +2,28 @@ import React from 'react'
 import { useBackend } from 'main/utils/useBackend';
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-// import StudentsTable from 'main/components/Students/StudentsTable';
+import UCSBSubjectsTable from 'main/components/UCSBSubjects/UCSBSubjectsTable';
+import { useCurrentUser } from 'main/utils/currentUser'
+
+import { subjectFixtures } from "fixtures/ucsbSubjectsFixtures";
 
 export default function UCSBSubjectsIndexPage() {
 
-  // const { data: students, error: _error, status: _status } =
-  //   useBackend(
-  //     // Stryker disable next-line all : don't test internal caching of React Query
-  //     ["/api/UCSBSubjects/all"],
-  //     { method: "GET", url: "/api/UCSBSubjects/all" },
-  //     []
-  //   );
+  const currentUser = useCurrentUser();
+
+  const { data: subjects, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/UCSBSubjects/all"],
+      { method: "GET", url: "/api/UCSBSubjects/all" },
+      []
+    );
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>UCSBSubjects</h1>
-        <p>[PLACEHOLDER]</p>
-        {/* <StudentsTable students={students} currentUser={currentUser} /> */}
+        <UCSBSubjectsTable subjects={subjects} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/utils/UCSBSubjectUtils.js
+++ b/frontend/src/main/utils/UCSBSubjectUtils.js
@@ -1,0 +1,18 @@
+import { toast } from "react-toastify";
+import { useNavigate } from 'react-router-dom'
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/UCSBSubjects/",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -213,6 +213,54 @@ describe("AppNavbar tests", () => {
 
     });
 
+    test("renders the ucsbsubjects menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-ucsbsubjects-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-ucsbsubjects-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId("appnavbar-ucsbsubjects-list")).toBeInTheDocument() );
+
+    });
+
+    test("renders the ucsbsubjects menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-ucsbsubjects-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-ucsbsubjects-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-ucsbsubjects-create/)).toBeInTheDocument() );
+
+    });
+
     test("renders the Students menu correctly for a user", async () => {
 
         const currentUser = currentUserFixtures.userOnly;

--- a/frontend/src/tests/components/UCSBSubjects/UCSBSubjectsTable.test.js
+++ b/frontend/src/tests/components/UCSBSubjects/UCSBSubjectsTable.test.js
@@ -1,0 +1,154 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { subjectFixtures } from "fixtures/ucsbSubjectsFixtures";
+import UCSBSubjectsTable from "main/components/UCSBSubjects/UCSBSubjectsTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBSubjectsTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBSubjectsTable subjects={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBSubjectsTable subjects={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("renders without crashing for empty table for admin", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBSubjectsTable subjects={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBSubjectsTable subjects={subjectFixtures.twoSubjects} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["ID", "Subject Code", "Subject Translation", "Department Code", "College Code", "Related Department Code", "Inactive"];
+    const expectedFields = ["id", "subjectCode", "subjectTranslation", "deptCode", "collegeCode", "relatedDeptCode", "inactive"];
+    const testId = "UCSBSubjectsTable";
+
+    expectedHeaders.forEach( (headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    } );
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    
+    expect(getByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("1A");
+    expect(getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("2A");
+
+    expect(getByTestId(`${testId}-cell-row-0-col-subjectTranslation`)).toHaveTextContent("1B");
+    expect(getByTestId(`${testId}-cell-row-1-col-subjectTranslation`)).toHaveTextContent("2B");
+
+    expect(getByTestId(`${testId}-cell-row-0-col-deptCode`)).toHaveTextContent("1C");
+    expect(getByTestId(`${testId}-cell-row-1-col-deptCode`)).toHaveTextContent("2C");
+
+    expect(getByTestId(`${testId}-cell-row-0-col-collegeCode`)).toHaveTextContent("1D");
+    expect(getByTestId(`${testId}-cell-row-1-col-collegeCode`)).toHaveTextContent("2D");
+
+    expect(getByTestId(`${testId}-cell-row-0-col-relatedDeptCode`)).toHaveTextContent("1E");
+    expect(getByTestId(`${testId}-cell-row-1-col-relatedDeptCode`)).toHaveTextContent("2E");
+
+    expect(getByTestId(`${testId}-cell-row-0-col-inactive`)).toHaveTextContent("true");
+    expect(getByTestId(`${testId}-cell-row-1-col-inactive`)).toHaveTextContent("false");
+
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBSubjectsTable subjects={subjectFixtures.twoSubjects} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(getByTestId(`UCSBSubjectsTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    const editButton = getByTestId(`UCSBSubjectsTable-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    
+    fireEvent.click(editButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbsubjects/edit/1'));
+
+  });
+
+  test("Delete button works without crashing", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBSubjectsTable subjects={subjectFixtures.twoSubjects} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(getByTestId(`UCSBSubjectsTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    const deleteButton = getByTestId(`UCSBSubjectsTable-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    
+    fireEvent.click(deleteButton);
+  });
+
+});
+

--- a/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsCreatePage.test.js
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import UCSBSubjectsCreatePage from "main/pages/UCSBSubjects/UCSBSubjectsCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("UCSBSubjectsCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
@@ -1,0 +1,165 @@
+import {  render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { subjectFixtures } from "fixtures/ucsbSubjectsFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+describe("UCSBSubjectsIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const testId = "UCSBSubjectsTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBSubjects/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBSubjects/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders two subjects without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBSubjects/all").reply(200, subjectFixtures.twoSubjects);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+            expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+            
+            expect(getByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("1A");
+            expect(getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("2A");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-subjectTranslation`)).toHaveTextContent("1B");
+            expect(getByTestId(`${testId}-cell-row-1-col-subjectTranslation`)).toHaveTextContent("2B");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-deptCode`)).toHaveTextContent("1C");
+            expect(getByTestId(`${testId}-cell-row-1-col-deptCode`)).toHaveTextContent("2C");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-collegeCode`)).toHaveTextContent("1D");
+            expect(getByTestId(`${testId}-cell-row-1-col-collegeCode`)).toHaveTextContent("2D");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-relatedDeptCode`)).toHaveTextContent("1E");
+            expect(getByTestId(`${testId}-cell-row-1-col-relatedDeptCode`)).toHaveTextContent("2E");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-inactive`)).toHaveTextContent("true");
+            expect(getByTestId(`${testId}-cell-row-1-col-inactive`)).toHaveTextContent("false");
+        });
+    });
+
+    test("renders two subjects without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBSubjects/all").reply(200, subjectFixtures.twoSubjects);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { 
+            expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+            expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+            
+            expect(getByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("1A");
+            expect(getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("2A");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-subjectTranslation`)).toHaveTextContent("1B");
+            expect(getByTestId(`${testId}-cell-row-1-col-subjectTranslation`)).toHaveTextContent("2B");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-deptCode`)).toHaveTextContent("1C");
+            expect(getByTestId(`${testId}-cell-row-1-col-deptCode`)).toHaveTextContent("2C");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-collegeCode`)).toHaveTextContent("1D");
+            expect(getByTestId(`${testId}-cell-row-1-col-collegeCode`)).toHaveTextContent("2D");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-relatedDeptCode`)).toHaveTextContent("1E");
+            expect(getByTestId(`${testId}-cell-row-1-col-relatedDeptCode`)).toHaveTextContent("2E");
+
+            expect(getByTestId(`${testId}-cell-row-0-col-inactive`)).toHaveTextContent("true");
+            expect(getByTestId(`${testId}-cell-row-1-col-inactive`)).toHaveTextContent("false");
+         });
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBSubjects/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        const { queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/UCSBSubjects/all");
+        restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+});

--- a/frontend/src/tests/utils/UCSBSubjectUtils.test.js
+++ b/frontend/src/tests/utils/UCSBSubjectUtils.test.js
@@ -1,0 +1,75 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete, editCallback } from "main/utils/UCSBSubjectUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UCSBSubjectUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 17 } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/UCSBSubjects/",
+                method: "DELETE",
+                params: { id: 17 }
+            });
+        });
+
+    });
+    // describe("editCallback", () => {
+
+    //     test("It pops up the expected toast", () => {
+    //         // arrange
+    //         const cell = { row: { values: { id: 17, name: "Groundhog Day" } } };
+    //         const expectedToast =  `Edit Callback called on id: 17 name: Groundhog Day`
+
+    //         // act
+    //         const result = editCallback(cell);
+
+    //         // assert
+
+    //         expect(mockToast).toHaveBeenCalledWith(expectedToast);
+           
+    //     });
+
+    // });
+});
+
+
+
+
+

--- a/src/main/java/edu/ucsb/cs156/example/controllers/CollegiateSubredditController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/CollegiateSubredditController.java
@@ -1,0 +1,163 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.CollegiateSubreddit;
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.models.CurrentUser;
+import edu.ucsb.cs156.example.repositories.CollegiateSubredditRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.Optional;
+
+
+@Api(description = "CollegiateSubreddit")
+@RequestMapping("/api/collegiateSubreddits")
+@RestController
+@Slf4j
+public class CollegiateSubredditController extends ApiController{
+    
+
+    public class CollegiateSubredditOrError {
+        Long id;
+        CollegiateSubreddit subreddit;
+        ResponseEntity<String> error;
+
+        public CollegiateSubredditOrError(Long id) {
+            this.id = id;
+        }
+    }
+
+
+    @Autowired
+    CollegiateSubredditRepository collegiateSubredditRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+
+    @ApiOperation(value = "List this user's collegiateSubreddit")
+    // @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<CollegiateSubreddit> getCollegiateSubreddit() {
+        // loggingService.logMethod();
+        Iterable<CollegiateSubreddit> collegiateSubreddit = collegiateSubredditRepository.findAll();
+        return collegiateSubreddit;
+    }
+
+    @ApiOperation(value = "Create a new subreddit")
+    // @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public CollegiateSubreddit postCollegiateSubreddit(
+            @ApiParam("name") @RequestParam String name,
+            @ApiParam("location") @RequestParam String location,
+            @ApiParam("subreddit") @RequestParam String subreddit) {
+        // loggingService.logMethod();
+        // CurrentUser currentUser = getCurrentUser();
+        // log.info("currentUser={}", currentUser);
+
+        CollegiateSubreddit collegiateSubreddit = new CollegiateSubreddit();
+        collegiateSubreddit.setName(name);
+        collegiateSubreddit.setLocation(location);
+        collegiateSubreddit.setSubreddit(subreddit);
+        CollegiateSubreddit savedcollegiateSubreddit = collegiateSubredditRepository.save(collegiateSubreddit);
+        return savedcollegiateSubreddit;
+    }
+
+
+    @ApiOperation(value = "Get a single subreddit")
+    // @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public ResponseEntity<String> getCollegiateSubredditById(
+            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+        // loggingService.logMethod();
+        CollegiateSubredditOrError toe = new CollegiateSubredditOrError(id);
+
+        toe = doesCollegiateSubredditExist(toe);
+        if (toe.error != null) {
+            return toe.error;
+        }
+        
+        String body = mapper.writeValueAsString(toe.subreddit);
+        return ResponseEntity.ok().body(body);
+    }
+
+
+    public CollegiateSubredditOrError doesCollegiateSubredditExist(CollegiateSubredditOrError toe) {
+
+        Optional<CollegiateSubreddit> optionalReq = collegiateSubredditRepository.findById(toe.id);
+
+        if (optionalReq.isEmpty()) {
+            toe.error = ResponseEntity
+                    .badRequest()
+                    .body(String.format("subreddit with id %d not found", toe.id));
+        } else {
+            toe.subreddit = optionalReq.get();
+        }
+        return toe;
+    }
+
+
+
+    @ApiOperation(value = "Update a single subreddit")
+    // @PreAuthorize("hasRole('ROLE_USER')")
+    @PutMapping("")
+    public ResponseEntity<String> putCollegiateSubredditById(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid CollegiateSubreddit incomingCollegiateSubreddit) throws JsonProcessingException {
+        // loggingService.logMethod();
+
+        CollegiateSubredditOrError coe = new CollegiateSubredditOrError(id);
+
+        coe = doesCollegiateSubredditExist(coe);
+        if (coe.error != null) {
+            return coe.error;
+        }
+        CollegiateSubreddit oldSubreddit = coe.subreddit;
+        oldSubreddit.setName(incomingCollegiateSubreddit.getName());
+        oldSubreddit.setLocation(incomingCollegiateSubreddit.getLocation());
+        oldSubreddit.setSubreddit(incomingCollegiateSubreddit.getSubreddit());
+
+        collegiateSubredditRepository.save(oldSubreddit);
+
+        String body = mapper.writeValueAsString(oldSubreddit);
+        return ResponseEntity.ok().body(body);
+    }
+
+
+    @ApiOperation(value = "Delete a subreddit by ID")
+    @DeleteMapping("")
+    public ResponseEntity<String> deleteCollegiateSubreddit(
+            @ApiParam("id") @RequestParam Long id) {
+        // loggingService.logMethod();
+
+        CollegiateSubredditOrError soe = new CollegiateSubredditOrError(id);
+
+        soe = doesCollegiateSubredditExist(soe);
+        if (soe.error != null) {
+            return soe.error;
+        }
+
+        collegiateSubredditRepository.deleteById(id);
+        return ResponseEntity.ok().body(String.format("subreddit with id %d deleted", id));
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBRequirementController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBRequirementController.java
@@ -1,0 +1,153 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBRequirement;
+import edu.ucsb.cs156.example.repositories.UCSBRequirementRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.Optional;
+
+@Api(description = "UCSB Requirements")
+@RequestMapping("/api/UCSBRequirements")
+@RestController
+public class UCSBRequirementController extends ApiController {
+
+    public class UCSBRequirementOrError {
+        Long id;
+        UCSBRequirement req;
+        ResponseEntity<String> error;
+
+        public UCSBRequirementOrError(Long id) {
+            this.id = id;
+        }
+    }
+
+    @Autowired
+    UCSBRequirementRepository ucsbRequirementRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "Get a single requirement by ID")
+    // @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public ResponseEntity<String> getUCSBRequirementById(
+            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+        // loggingService.logMethod();
+        UCSBRequirementOrError roe = new UCSBRequirementOrError(id);
+
+        roe = doesUCSBRequirementExist(roe);
+        if (roe.error != null) {
+            return roe.error;
+        }
+        
+        String body = mapper.writeValueAsString(roe.req);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @ApiOperation(value = "Delete a requirement by ID")
+    @DeleteMapping("")
+    public ResponseEntity<String> deleteUCSBRequirement(
+            @ApiParam("id") @RequestParam Long id) {
+        // loggingService.logMethod();
+
+        UCSBRequirementOrError roe = new UCSBRequirementOrError(id);
+
+        roe = doesUCSBRequirementExist(roe);
+        if (roe.error != null) {
+            return roe.error;
+        }
+
+        ucsbRequirementRepository.deleteById(id);
+        return ResponseEntity.ok().body(String.format("requirement with id %d deleted", id));
+
+    }
+
+    @ApiOperation(value = "Update a single requirement by ID")
+    @PutMapping("")
+    public ResponseEntity<String> putTodoById(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid UCSBRequirement incomingUCSBRequirement) throws JsonProcessingException {
+        // loggingService.logMethod();
+
+        UCSBRequirementOrError roe = new UCSBRequirementOrError(id);
+
+        roe = doesUCSBRequirementExist(roe);
+        if (roe.error != null) {
+            return roe.error;
+        }
+
+        ucsbRequirementRepository.save(incomingUCSBRequirement);
+
+        String body = mapper.writeValueAsString(incomingUCSBRequirement);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @ApiOperation(value = "List all requirements")
+    @GetMapping("/all")
+    public Iterable<UCSBRequirement> allUCSBRequirements() {
+        // loggingService.logMethod();
+        Iterable<UCSBRequirement> reqs = ucsbRequirementRepository.findAll();
+        return reqs;
+    }
+
+    @ApiOperation(value = "Create a new requirement")
+    @PostMapping("/post")
+    public UCSBRequirement postUcsbRequirement(
+            @ApiParam("requirementCode") @RequestParam String requirementCode,
+            @ApiParam("requirementTranslation") @RequestParam String requirementTranslation,
+            @ApiParam("collegeCode") @RequestParam String collegeCode,
+            @ApiParam("objCode") @RequestParam String objCode,
+            @ApiParam("courseCount") @RequestParam int courseCount,
+            @ApiParam("units") @RequestParam int units,
+            @ApiParam("inactive") @RequestParam Boolean inactive,
+            @ApiParam("id") @RequestParam long id) {
+        // loggingService.logMethod();
+
+        UCSBRequirement req = new UCSBRequirement();
+        req.setRequirementCode(requirementCode);
+        req.setRequirementTranslation(requirementTranslation);
+        req.setCollegeCode(collegeCode);
+        req.setObjCode(objCode);
+        req.setCourseCount(courseCount);
+        req.setUnits(units);
+        req.setInactive(inactive);
+        req.setId(id);
+        
+        UCSBRequirement savedReq = ucsbRequirementRepository.save(req);
+        return savedReq;
+    }
+    
+
+    public UCSBRequirementOrError doesUCSBRequirementExist(UCSBRequirementOrError roe) {
+
+        Optional<UCSBRequirement> optionalReq = ucsbRequirementRepository.findById(roe.id);
+
+        if (optionalReq.isEmpty()) {
+            roe.error = ResponseEntity
+                    .badRequest()
+                    .body(String.format("requirement with id %d not found", roe.id));
+        } else {
+            roe.req = optionalReq.get();
+        }
+        return roe;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectController.java
@@ -1,0 +1,160 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.UCSBSubject;
+import edu.ucsb.cs156.example.repositories.UCSBSubjectRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.Optional;
+
+@Api(description = "UCSBSubjects")
+@RequestMapping("/api/UCSBSubjects/")
+@RestController
+@Slf4j
+public class UCSBSubjectController extends ApiController {
+
+    //    /**
+//     * This inner class helps us factor out some code for checking
+//     * whether todos exist, and whether they belong to the current user,
+//     * along with the error messages pertaining to those situations. It
+//     * bundles together the state needed for those checks.
+//     */
+    public class UCSBSubjectOrError {
+        Long id;
+        UCSBSubject ucsbSubject;
+        ResponseEntity<String> error;
+
+        public UCSBSubjectOrError(Long id) {
+            this.id = id;
+        }
+    }
+
+    @Autowired
+    UCSBSubjectRepository ucsbSubjectRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "List all UCSB Subjects")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBSubject> allUCSBSubjects() {
+        // loggingService.logMethod();
+        return ucsbSubjectRepository.findAll();
+    }
+
+    @ApiOperation(value = "Get a single UCSBSubject")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public ResponseEntity<String> getUCSBSubjectById(
+            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+        // loggingService.logMethod();
+
+        UCSBSubjectOrError usoe = new UCSBSubjectOrError(id);
+
+        usoe = doesUCSBSubjectExist(usoe);
+        if (usoe.error != null) {
+            return usoe.error;
+        }
+
+        String body = mapper.writeValueAsString(usoe.ucsbSubject);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @ApiOperation(value = "Create a new UCSBSubject JSON object")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBSubject postUCSBSubject(
+            @ApiParam("subjectCode") @RequestParam String subjectCode,
+            @ApiParam("subjectTranslation") @RequestParam String subjectTranslation,
+            @ApiParam("deptCode") @RequestParam String deptCode,
+            @ApiParam("collegeCode") @RequestParam String collegeCode,
+            @ApiParam("relatedDeptCode") @RequestParam String relatedDeptCode,
+            @ApiParam("inactive") @RequestParam boolean inactive) {
+        // loggingService.logMethod();
+        log.info("UCSB subject /post called: subjectCode={}, subjectTranslation={}, " +
+                        "deptCode={}, collegeCode={}, relatedDeptCode={}, inactive={}",
+                subjectCode, subjectTranslation, deptCode, collegeCode, relatedDeptCode, inactive);
+        final var ucsbSubject = new UCSBSubject();
+        ucsbSubject.setSubjectCode(subjectCode);
+        ucsbSubject.setSubjectTranslation(subjectTranslation);
+        ucsbSubject.setDeptCode(deptCode);
+        ucsbSubject.setCollegeCode(collegeCode);
+        ucsbSubject.setRelatedDeptCode(relatedDeptCode);
+        ucsbSubject.setInactive(inactive);
+
+        return ucsbSubjectRepository.save(ucsbSubject);
+    }
+
+    @ApiOperation(value = "Delete a UCSBSubject")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public ResponseEntity<String> deleteUCSBSubject(
+            @ApiParam("id") @RequestParam Long id) {
+        // loggingService.logMethod();
+
+        UCSBSubjectOrError usoe = new UCSBSubjectOrError(id);
+
+        usoe = doesUCSBSubjectExist(usoe);
+        if (usoe.error != null) {
+            return usoe.error;
+        }
+
+        ucsbSubjectRepository.deleteById(id);
+        return ResponseEntity.ok().body(String.format("UCSBSubject with id %d deleted", id));
+
+    }
+
+    @ApiOperation(value = "Update a single UCSBSubject")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public ResponseEntity<String> putUCSBSubjectById(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid UCSBSubject incomingUCSBSubject) throws JsonProcessingException {
+        // loggingService.logMethod();
+
+        UCSBSubjectOrError usoe = new UCSBSubjectOrError(id);
+
+        usoe = doesUCSBSubjectExist(usoe);
+        if (usoe.error != null) {
+            return usoe.error;
+        }
+
+        ucsbSubjectRepository.save(incomingUCSBSubject);
+
+        String body = mapper.writeValueAsString(incomingUCSBSubject);
+        return ResponseEntity.ok().body(body);
+    }
+
+    /**
+     * Pre-conditions: usoe.id is value to look up, usoe.todo and usoe.error are null
+     * <p>
+     * Post-condition: if todo with id usoe.id exists, usoe.todo now refers to it, and
+     * error is null.
+     * Otherwise, todo with id usoe.id does not exist, and error is a suitable return
+     * value to
+     * report this error condition.
+     */
+    public UCSBSubjectOrError doesUCSBSubjectExist(UCSBSubjectOrError usoe) {
+
+        Optional<UCSBSubject> optionalUCSBSubject = ucsbSubjectRepository.findById(usoe.id);
+
+        if (optionalUCSBSubject.isEmpty()) {
+            usoe.error = ResponseEntity
+                    .badRequest()
+                    .body(String.format("UCSB Subject with id %d not found", usoe.id));
+        } else {
+            usoe.ucsbSubject = optionalUCSBSubject.get();
+        }
+        return usoe;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/CollegiateSubreddit.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/CollegiateSubreddit.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.entities;
+
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "collegiate_subreddits")
+public class CollegiateSubreddit {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  // This establishes that many todos can belong to one user
+  // Only the user_id is stored in the table, and through it we
+  // can access the user's details
+
+
+  private String name;
+  private String location;
+  private String subreddit;
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBRequirement.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBRequirement.java
@@ -1,0 +1,31 @@
+package edu.ucsb.cs156.example.entities;
+
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsb_requirements")
+public class UCSBRequirement {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requirementCode;
+  private String requirementTranslation;
+  private String collegeCode;
+  private String objCode;
+  private int courseCount;
+  private int units;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBSubject.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBSubject.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.example.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+/*
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsb_subjects")
+public class UCSBSubject {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    // This establishes that many todos can belong to one user
+    // Only the user_id is stored in the table, and through it we
+    // can access the user's details
+
+    private String subjectCode;
+    private String subjectTranslation;
+    private String deptCode;
+    private String collegeCode;
+    private String relatedDeptCode;
+    private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/CollegiateSubredditRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/CollegiateSubredditRepository.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.CollegiateSubreddit;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CollegiateSubredditRepository extends CrudRepository<CollegiateSubreddit, Long> {
+
+  Iterable<CollegiateSubreddit> findByName(String name);
+  Iterable<CollegiateSubreddit> findBySubreddit(String subreddit);
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBRequirementRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBRequirementRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBRequirement;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UCSBRequirementRepository extends CrudRepository<UCSBRequirement, Long> {
+  Optional<UCSBRequirement> findById(Long id);
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBSubjectRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBSubjectRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+
+import edu.ucsb.cs156.example.entities.UCSBSubject;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UCSBSubjectRepository extends CrudRepository<UCSBSubject, Long> {
+    Iterable<UCSBSubject> findAllBySubjectCode(String subject);
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/CollegiateSubredditControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/CollegiateSubredditControllerTests.java
@@ -1,0 +1,361 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.CollegiateSubreddit;
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.repositories.CollegiateSubredditRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = CollegiateSubredditController.class)
+@Import(TestConfig.class)
+public class CollegiateSubredditControllerTests extends ControllerTestCase {
+
+    @MockBean
+    CollegiateSubredditRepository collegiateSubredditRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Authorization tests
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_collegiateSubreddits_all__user_logged_in__returns_200() throws Exception {
+        mockMvc.perform(get("/api/collegiateSubreddits/all"))
+                .andExpect(status().isOk());
+    }
+
+
+    // Tests with mocks for database actions on user
+
+  
+
+
+    // Tests with mocks for database actions on user on GET(Index) and Post(Create)
+
+
+
+    // @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_collegiateSubreddit_user_get_all() throws Exception {
+        // arrange
+
+        // User u = currentUserService.getCurrentUser().getUser();
+
+        CollegiateSubreddit expectedSubreddit1 = CollegiateSubreddit.builder()
+                .name("Name1")
+                .location("Location1")
+                .subreddit("Subreddit1")
+                .id(0L)
+                .build();
+        CollegiateSubreddit expectedSubreddit2 = CollegiateSubreddit.builder()
+                .name("Name2")
+                .location("Location2")
+                .subreddit("Subreddit2")
+                .id(1L)
+                .build();
+        CollegiateSubreddit expectedSubreddit3 = CollegiateSubreddit.builder()
+                .name("Name3")
+                .location("Location3")
+                .subreddit("Subreddit3")
+                .id(2L)
+                .build();
+
+        ArrayList<CollegiateSubreddit> expectedSubreddits = new ArrayList<>();
+        expectedSubreddits.addAll(Arrays.asList(expectedSubreddit1,expectedSubreddit2, expectedSubreddit3));
+
+        when(collegiateSubredditRepository.findAll()).thenReturn(expectedSubreddits);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                get("/api/collegiateSubreddits/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(collegiateSubredditRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedSubreddits);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+
+
+    // Tests for Get(Show) Method
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_collegiateSubreddit_user_post__user_logged_in() throws Exception {
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+
+        CollegiateSubreddit expectedSubreddit = CollegiateSubreddit.builder()
+                .name("Name1")
+                .location("Location1")
+                .subreddit("Subreddit1")
+                .id(0L)
+                .build();
+
+        when(collegiateSubredditRepository.save(eq(expectedSubreddit))).thenReturn(expectedSubreddit);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/collegiateSubreddits/post?name=Name1&location=Location1&subreddit=Subreddit1")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(collegiateSubredditRepository, times(1)).save(expectedSubreddit);
+        String expectedJson = mapper.writeValueAsString(expectedSubreddit);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_collegiateSubreddits_user_returns_a_collegiateSubreddit_that_exists() throws Exception {
+
+        User u = currentUserService.getCurrentUser().getUser();
+        // arrange
+        CollegiateSubreddit collegiateSubreddit1 = CollegiateSubreddit.builder()
+                                                                        .name("UCSB")
+                                                                        .location("Santa Barbara")
+                                                                        .subreddit("UCSantaBarbara")
+                                                                        .id(7L)
+                                                                        .build();
+        when(collegiateSubredditRepository.findById(eq(7L))).thenReturn(Optional.of(collegiateSubreddit1));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/collegiateSubreddits?id=7"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(collegiateSubredditRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(collegiateSubreddit1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_collegiateSubreddits_user_search_for_collegiateSubreddit_that_does_not_exist() throws Exception {
+
+        User u = currentUserService.getCurrentUser().getUser();
+        // arrange
+        when(collegiateSubredditRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/collegiateSubreddits?id=7"))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(collegiateSubredditRepository, times(1)).findById(eq(7L));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("subreddit with id 7 not found", responseString);
+    }
+
+
+
+    // Tests for Get(show) on admin
+
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void api_collegiateSubreddits_admin_returns_a_collegiateSubreddit_that_exists() throws Exception {
+
+        // arrange
+        CollegiateSubreddit collegiateSubreddit1 = CollegiateSubreddit.builder()
+                                                                        .name("UCSB")
+                                                                        .location("Santa Barbara")
+                                                                        .subreddit("UCSantaBarbara")
+                                                                        .id(7L)
+                                                                        .build();
+        when(collegiateSubredditRepository.findById(eq(7L))).thenReturn(Optional.of(collegiateSubreddit1));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/collegiateSubreddits?id=7"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(collegiateSubredditRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(collegiateSubreddit1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void api_collegiateSubreddits_admin_search_for_collegiateSubreddit_that_does_not_exist() throws Exception {
+
+        // arrange
+        when(collegiateSubredditRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/collegiateSubreddits?id=7"))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(collegiateSubredditRepository, times(1)).findById(eq(7L));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("subreddit with id 7 not found", responseString);
+    }
+
+
+
+    // Tests for Put(edit) method
+
+    @Test
+    public void api_collegiateSubreddit__put_exist() throws Exception {
+        
+        // arrange
+
+        // User u = currentUserService.getCurrentUser().getUser();
+        // User otherUser = User.builder().id(999).build();
+        
+        // We deliberately set the user information to another user
+        // This shoudl get ignored and overwritten with currrent user when CollegiateSubreddit is saved
+
+        CollegiateSubreddit initialCollegiateSubreddit = CollegiateSubreddit.builder()
+                                                                            .name("Name1")
+                                                                            .location("Location1")
+                                                                            .subreddit("Subreddit1")
+                                                                            .id(10L)
+                                                                            .build();
+
+        CollegiateSubreddit updatedCollegiateSubreddit = CollegiateSubreddit.builder()
+                                                                            .name("changed")
+                                                                            .location("changed")
+                                                                            .subreddit("changed")
+                                                                            .id(10L)
+                                                                            .build();
+        
+
+        String requestBody = mapper.writeValueAsString(updatedCollegiateSubreddit);
+        String expectedReturn = mapper.writeValueAsString(updatedCollegiateSubreddit);
+
+        when(collegiateSubredditRepository.findById(eq(10L))).thenReturn(Optional.of(initialCollegiateSubreddit));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/collegiateSubreddits?id=10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(collegiateSubredditRepository, times(1)).findById(10L);
+        verify(collegiateSubredditRepository, times(1)).save(updatedCollegiateSubreddit); 
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
+
+
+    @Test
+    public void api_collegiateSubreddit__put_not_exist() throws Exception {
+        
+        // arrange
+
+        CollegiateSubreddit updatedCollegiateSubreddit = CollegiateSubreddit.builder()
+                                                                            .name("Name1")
+                                                                            .location("Location1")
+                                                                            .subreddit("Subreddit1")
+                                                                            .id(10L)
+                                                                            .build();
+
+        
+
+        String requestBody = mapper.writeValueAsString(updatedCollegiateSubreddit);
+
+        when(collegiateSubredditRepository.findById(eq(10L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/collegiateSubreddits?id=10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(collegiateSubredditRepository, times(1)).findById(10L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("subreddit with id 10 not found", responseString);
+    }
+
+
+
+    @Test
+    public void api_CollegiateSubreddit__delete_exist() throws Exception {
+
+        // arrange
+        CollegiateSubreddit collegiateSubreddit1 = CollegiateSubreddit.builder().name("CollegiateSubreddit1").location("CollegiateSubreddit1").subreddit("CollegiateSubreddit1").id(123L).build();
+        when(collegiateSubredditRepository.findById(eq(123L))).thenReturn(Optional.of(collegiateSubreddit1));
+
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/collegiateSubreddits?id=123")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(collegiateSubredditRepository, times(1)).findById(123L);
+        verify(collegiateSubredditRepository, times(1)).deleteById(123L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("subreddit with id 123 deleted", responseString);
+    }
+
+
+    @Test
+    public void api_collegiateSubreddit__delete_does_not_exist() throws Exception {
+        // arrange
+
+        User otherUser = User.builder().id(98L).build();
+
+        CollegiateSubreddit collegiateSubreddit1 = CollegiateSubreddit.builder().name("CollegiateSubreddit1").location("CollegiateSubreddit1").subreddit("CollegiateSubreddit1").id(123L).build();
+        when(collegiateSubredditRepository.findById(eq(123L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/collegiateSubreddits?id=123")
+                        .with(csrf()))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(collegiateSubredditRepository, times(1)).findById(123L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("subreddit with id 123 not found", responseString);
+    }
+
+
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/CollegiateSubredditsTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/CollegiateSubredditsTests.java
@@ -1,0 +1,5 @@
+package edu.ucsb.cs156.example.controllers;
+
+public class CollegiateSubredditsTests {
+    
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBRequirementControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBRequirementControllerTests.java
@@ -1,0 +1,366 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UCSBRequirementRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBRequirement;
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBRequirementController.class)
+@Import(TestConfig.class)
+public class UCSBRequirementControllerTests extends ControllerTestCase {
+
+    @MockBean
+    UCSBRequirementRepository ucsbRequirementRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Tests with mocks for database actions
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_reqs__user_logged_in__returns_a_req_that_exists() throws Exception {
+
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        UCSBRequirement req1 = UCSBRequirement.builder()
+                .requirementCode("X")
+                .requirementTranslation("X")
+                .collegeCode("X")
+                .objCode("X")
+                .courseCount(0)
+                .units(0)
+                .inactive(false)
+                .id(7L).build();
+
+        when(ucsbRequirementRepository.findById(eq(7L))).thenReturn(Optional.of(req1));
+
+        // act
+
+        MvcResult response = mockMvc.perform(get("/api/UCSBRequirements?id=7"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbRequirementRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(req1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_reqs__user_logged_in__search_for_req_that_does_not_exist() throws Exception {
+
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+
+        when(ucsbRequirementRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBRequirements?id=7"))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+
+        verify(ucsbRequirementRepository, times(1)).findById(eq(7L));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("requirement with id 7 not found", responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void api_reqs__admin_logged_in__returns_a_req_that_exists() throws Exception {
+
+        // arrange
+
+        UCSBRequirement req1 = UCSBRequirement.builder()
+                .requirementCode("X")
+                .requirementTranslation("X")
+                .collegeCode("X")
+                .objCode("X")
+                .courseCount(0)
+                .units(0)
+                .inactive(false)
+                .id(7L).build();
+
+        when(ucsbRequirementRepository.findById(eq(7L))).thenReturn(Optional.of(req1));
+
+        // act
+
+        MvcResult response = mockMvc.perform(get("/api/UCSBRequirements?id=7"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbRequirementRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(req1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void api_req__admin_logged_in__search_for_req_that_does_not_exist() throws Exception {
+
+        // arrange
+
+        when(ucsbRequirementRepository.findById(eq(29L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBRequirements?id=29"))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+
+        verify(ucsbRequirementRepository, times(1)).findById(eq(29L));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("requirement with id 29 not found", responseString);
+    }
+
+    @Test
+    public void api_reqs__delete_req() throws Exception {
+        
+        // arrange
+
+        UCSBRequirement req1 = UCSBRequirement.builder()
+                .requirementCode("X")
+                .requirementTranslation("X")
+                .collegeCode("X")
+                .objCode("X")
+                .courseCount(0)
+                .units(0)
+                .inactive(false)
+                .id(42L).build();
+
+        when(ucsbRequirementRepository.findById(eq(42L))).thenReturn(Optional.of(req1));
+
+        // act
+
+        MvcResult response = mockMvc.perform(
+                delete("/api/UCSBRequirements?id=42")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbRequirementRepository, times(1)).findById(42L);
+        verify(ucsbRequirementRepository, times(1)).deleteById(42L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("requirement with id 42 deleted", responseString);
+    }
+
+    @Test
+    public void api_reqs__delete_req_that_does_not_exist() throws Exception {
+        
+        // arrange
+
+        when(ucsbRequirementRepository.findById(eq(42L))).thenReturn(Optional.empty());
+
+        // act
+
+        MvcResult response = mockMvc.perform(
+                delete("/api/UCSBRequirements?id=42")
+                        .with(csrf()))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+
+        verify(ucsbRequirementRepository, times(1)).findById(42L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("requirement with id 42 not found", responseString);
+    }
+
+    @Test
+    public void api_reqs__put_req() throws Exception {
+        
+        // arrange
+
+        UCSBRequirement initialReq = UCSBRequirement.builder()
+                .requirementCode("X")
+                .requirementTranslation("X")
+                .collegeCode("X")
+                .objCode("X")
+                .courseCount(0)
+                .units(0)
+                .inactive(false)
+                .id(42L).build();
+
+        UCSBRequirement updatedReq = UCSBRequirement.builder()
+                .requirementCode("New Req Code")
+                .requirementTranslation("New Req Translation")
+                .collegeCode("New College Code")
+                .objCode("New Obj Code")
+                .courseCount(10)
+                .units(10)
+                .inactive(true)
+                .id(42L).build();
+
+        String requestBody = mapper.writeValueAsString(updatedReq);
+        String expectedReturn = mapper.writeValueAsString(updatedReq);
+
+        when(ucsbRequirementRepository.findById(eq(42L))).thenReturn(Optional.of(initialReq));
+
+        // act
+
+        MvcResult response = mockMvc.perform(
+                put("/api/UCSBRequirements?id=42")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbRequirementRepository, times(1)).findById(42L);
+        verify(ucsbRequirementRepository, times(1)).save(updatedReq);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
+
+    @Test
+    public void api_reqs__cannot_put_req_that_does_not_exist() throws Exception {
+        
+        // arrange
+
+        UCSBRequirement updatedReq = UCSBRequirement.builder()
+                .requirementCode("New Req Code")
+                .requirementTranslation("New Req Translation")
+                .collegeCode("New College Code")
+                .objCode("New Obj Code")
+                .courseCount(10)
+                .units(10)
+                .inactive(true)
+                .id(42L).build();
+
+        String requestBody = mapper.writeValueAsString(updatedReq);
+
+        when(ucsbRequirementRepository.findById(eq(42L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/UCSBRequirements?id=42")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(ucsbRequirementRepository, times(1)).findById(42L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("requirement with id 42 not found", responseString);
+    }
+
+    @Test
+    public void api_reqs_all__returns_all_reqs() throws Exception {
+
+        // arrange
+
+        UCSBRequirement req1 = UCSBRequirement.builder()
+                .requirementCode("A")
+                .requirementTranslation("A")
+                .collegeCode("A")
+                .objCode("A")
+                .courseCount(1)
+                .units(1)
+                .inactive(false)
+                .id(1L).build();
+
+        UCSBRequirement req2 = UCSBRequirement.builder()
+                .requirementCode("B")
+                .requirementTranslation("B")
+                .collegeCode("B")
+                .objCode("B")
+                .courseCount(2)
+                .units(2)
+                .inactive(false)
+                .id(2L).build();
+
+        UCSBRequirement req3 = UCSBRequirement.builder()
+                .requirementCode("C")
+                .requirementTranslation("C")
+                .collegeCode("C")
+                .objCode("C")
+                .courseCount(3)
+                .units(3)
+                .inactive(false)
+                .id(3L).build();
+
+        ArrayList<UCSBRequirement> expectedReqs = new ArrayList<>();
+        expectedReqs.addAll(Arrays.asList(req1, req2, req3));
+
+        when(ucsbRequirementRepository.findAll()).thenReturn(expectedReqs);
+
+        // act
+
+        MvcResult response = mockMvc.perform(get("/api/UCSBRequirements/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbRequirementRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedReqs);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @Test
+    public void api_reqs_post() throws Exception {
+        
+        // arrange
+
+        UCSBRequirement expectedReq = UCSBRequirement.builder()
+                .requirementCode("A")
+                .requirementTranslation("B")
+                .collegeCode("C")
+                .objCode("D")
+                .courseCount(100)
+                .units(100)
+                .inactive(true)
+                .id(42L).build();
+
+        when(ucsbRequirementRepository.save(eq(expectedReq))).thenReturn(expectedReq);
+
+        // act
+
+        MvcResult response = mockMvc.perform(
+                post("/api/UCSBRequirements/post?requirementCode=A&requirementTranslation=B&collegeCode=C&objCode=D&courseCount=100&units=100&inactive=true&id=42")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(ucsbRequirementRepository, times(1)).save(expectedReq);
+        String expectedJson = mapper.writeValueAsString(expectedReq);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectsControllerTests.java
@@ -1,0 +1,424 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBSubject;
+import edu.ucsb.cs156.example.repositories.UCSBSubjectRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UCSBSubjectController.class)
+@Import(TestConfig.class)
+public class UCSBSubjectsControllerTests extends ControllerTestCase {
+
+    @MockBean
+    UCSBSubjectRepository ucsbSubjectRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // tests for /api/ucsbSubjects/all
+
+    @Test
+    public void api_ucsbSubjects_all__logged_out__returns_403() throws Exception {
+        mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().is(403));
+    }
+
+    @Test
+    @WithMockUser(roles = {"USER"})
+    public void api_ucsbSubjects_all__user_logged_in__returns_200() throws Exception {
+        mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().is(200));
+    }
+
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void api_UCSBSubjects_all__user_logged_in__returns_all_UCSBSubjects() throws Exception {
+        UCSBSubject UCSBSubject1 = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(1L)
+                .build();
+
+        UCSBSubject UCSBSubject2 = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(2L)
+                .build();
+
+        UCSBSubject UCSBSubject3 = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(3L)
+                .build();
+
+        ArrayList<UCSBSubject> expectedUCSBSubjects = new ArrayList<>(
+                Arrays.asList(UCSBSubject1, UCSBSubject2, UCSBSubject3));
+
+        when(ucsbSubjectRepository.findAll()).thenReturn(expectedUCSBSubjects);
+
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(ucsbSubjectRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedUCSBSubjects);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN", "USER"})
+    public void api_ucsbSubjects_all__admin_logged_in__returns_200() throws Exception {
+        mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().is(200));
+    }
+
+
+    @WithMockUser(roles = {"ADMIN", "USER"})
+    @Test
+    public void api_UCSBSubjects_all__admin_logged_in__returns_all_UCSBSubjects() throws Exception {
+
+        UCSBSubject UCSBSubject1 = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(1L)
+                .build();
+
+        UCSBSubject UCSBSubject2 = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(2L)
+                .build();
+
+        UCSBSubject UCSBSubject3 = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(3L)
+                .build();
+
+        ArrayList<UCSBSubject> expectedUCSBSubjects = new ArrayList<>(
+                Arrays.asList(UCSBSubject1, UCSBSubject2, UCSBSubject3));
+
+        when(ucsbSubjectRepository.findAll()).thenReturn(expectedUCSBSubjects);
+
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        verify(ucsbSubjectRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedUCSBSubjects);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    // tests for /api/ucsbSubjects/post
+
+    @Test
+    public void api_ucsbSubjects_post__logged_out__returns_403() throws Exception {
+        mockMvc.perform(post("/api/UCSBSubjects/post"))
+                .andExpect(status().is(403));
+    }
+
+    @Test
+    @WithMockUser(roles = {"USER"})
+    public void api_ucsbSubjects_post__user_logged_in__returns_403() throws Exception {
+        mockMvc.perform(post("/api/UCSBSubjects/post"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = {"ADMIN", "USER"})
+    @Test
+    public void api_UCSBSubjects_post__admin_logged_in() throws Exception {
+        // arrange
+
+        UCSBSubject expectedUCSBSubject = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(0L)
+                .build();
+
+        when(ucsbSubjectRepository.save(eq(expectedUCSBSubject))).thenReturn(expectedUCSBSubject);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        post("/api/UCSBSubjects/post?id=0&subjectCode=A&subjectTranslation=B&collegeCode=C&deptCode=D&relatedDeptCode=E&inactive=true")
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbSubjectRepository, times(1)).save(expectedUCSBSubject);
+        String expectedJson = mapper.writeValueAsString(expectedUCSBSubject);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+
+    // Tests with mocks for database actions
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void api_ucsbSubjects__user_logged_in__returns_a_ucsbSubject_that_exists() throws Exception {
+
+        UCSBSubject ucsbSubject1 = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(1L)
+                .build();
+
+
+        when(ucsbSubjectRepository.findById(eq(1L))).thenReturn(Optional.of(ucsbSubject1));
+
+
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/?id=1"))
+                .andExpect(status().isOk()).andReturn();
+
+
+        verify(ucsbSubjectRepository, times(1)).findById(eq(1L));
+        String expectedJson = mapper.writeValueAsString(ucsbSubject1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void api_ucsbSubjects__user_logged_in__search_for_ucsbSubject_that_does_not_exist() throws Exception {
+
+        when(ucsbSubjectRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/?id=1"))
+                .andExpect(status().isBadRequest()).andReturn();
+
+
+        verify(ucsbSubjectRepository, times(1)).findById(eq(1L));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("UCSB Subject with id 1 not found", responseString);
+    }
+
+
+//     @WithMockUser(roles = { "ADMIN" })
+//     @Test
+//     public void api_ucsbSubject__admin_logged_in__search_for_ucsbSubject_that_belongs_to_another_user() throws Exception {
+
+//         User u = currentUserService.getCurrentUser().getUser();
+//         User otherUser = User.builder().id(999L).build();
+//         UCSBSubject otherUsersUCSBSubject = UCSBSubject.builder()
+//                 .subjectCode("A")
+//                 .subjectTranslation("B")
+//                 .collegeCode("C")
+//                 .deptCode("D")
+//                 .relatedDeptCode("E")
+//                 .inactive(true)
+//                 .id(999L)
+//                 .build();
+
+//         when(ucsbSubjectRepository.findById(eq(999L))).thenReturn(Optional.of(otherUsersUCSBSubject));
+
+//         MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?id=999"))
+//                 .andExpect(status().isOk()).andReturn();
+
+
+//         verify(ucsbSubjectRepository, times(1)).findById(eq(0L));
+//         String expectedJson = mapper.writeValueAsString(otherUsersUCSBSubject);
+//         String responseString = response.getResponse().getContentAsString();
+//         assertEquals(expectedJson, responseString);
+//     }
+
+    @WithMockUser(roles = {"ADMIN", "USER"})
+    @Test
+    public void api_ucsbSubjects__admin_logged_in__search_for_ucsbSubject_that_does_not_exist() throws Exception {
+
+
+        when(ucsbSubjectRepository.findById(eq(0L))).thenReturn(Optional.empty());
+
+
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/?id=0"))
+                .andExpect(status().isBadRequest()).andReturn();
+
+
+        verify(ucsbSubjectRepository, times(1)).findById(eq(0L));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("UCSB Subject with id 0 not found", responseString);
+    }
+
+
+    @WithMockUser(roles = {"ADMIN", "USER"})
+    @Test
+    public void api_UCSBSubject__admin_logged_in__delete_UCSBSubject() throws Exception {
+        // arrange
+
+        UCSBSubject ucsbSubject1 = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(1L)
+                .build();
+
+        when(ucsbSubjectRepository.findById(eq(1L))).thenReturn(Optional.of(ucsbSubject1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        delete("/api/UCSBSubjects/?id=1")
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbSubjectRepository, times(1)).findById(1L);
+        verify(ucsbSubjectRepository, times(1)).deleteById(1L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("UCSBSubject with id 1 deleted", responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN", "USER"})
+    @Test
+    public void api_UCSBSubjects__admin_logged_in__cannot_delete_UCSBSubject_that_does_not_exist() throws Exception {
+        // arrange
+
+        when(ucsbSubjectRepository.findById(eq(17L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        delete("/api/UCSBSubjects/?id=17")
+                                .with(csrf()))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(ucsbSubjectRepository, times(1)).findById(17L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("UCSB Subject with id 17 not found", responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN", "USER"})
+    @Test
+    public void api_ucsbSubjects__admin_logged_in__put_ucsbSubject() throws Exception {
+        // arrange
+
+        UCSBSubject ucsbSubject1 = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(1L)
+                .build();
+        // We deliberately put the wrong user on the updated todo
+        // We expect the controller to ignore this and keep the user the same
+        UCSBSubject updatedUCSBSubject = UCSBSubject.builder()
+                .subjectCode("F")
+                .subjectTranslation("G")
+                .collegeCode("H")
+                .deptCode("I")
+                .relatedDeptCode("J")
+                .inactive(true)
+                .id(1L)
+                .build();
+
+        String expectedJson = mapper.writeValueAsString(updatedUCSBSubject);
+        String requestBody = mapper.writeValueAsString(updatedUCSBSubject);
+        when(ucsbSubjectRepository.findById(eq(1L))).thenReturn(Optional.of(ucsbSubject1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        put("/api/UCSBSubjects/?id=1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                                .content(requestBody)
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(ucsbSubjectRepository, times(1)).findById(1L);
+        verify(ucsbSubjectRepository, times(1)).save(updatedUCSBSubject);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN", "USER"})
+    @Test
+    public void api_ucsbSubjects__admin_logged_in__cannot_put_ucsbSubject_that_does_not_exist() throws Exception {
+        // arrange
+
+        UCSBSubject updatedUCSBSubject = UCSBSubject.builder()
+                .subjectCode("A")
+                .subjectTranslation("B")
+                .collegeCode("C")
+                .deptCode("D")
+                .relatedDeptCode("E")
+                .inactive(true)
+                .id(1L)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(updatedUCSBSubject);
+
+        when(ucsbSubjectRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        put("/api/UCSBSubjects/?id=1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                                .content(requestBody)
+                                .with(csrf()))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(ucsbSubjectRepository, times(1)).findById(1L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("UCSB Subject with id 1 not found", responseString);
+    }
+
+}


### PR DESCRIPTION
# Overview

This pull request adds a "Delete" button to table entries in the UCSBSubjects list page, which allows administrators to delete individual subjects (#17).

# Details

Initial state with delete buttons visible:
![Screen Shot 2022-02-18 at 5 25 38 PM](https://user-images.githubusercontent.com/24759371/154780722-1c7b7daa-0193-4eda-adde-510017aacaaa.png)

State after pressing delete on entry with an `id` of 1 (entry disappears, toast notifies user of delete action):
![Screen Shot 2022-02-18 at 5 26 04 PM](https://user-images.githubusercontent.com/24759371/154780766-14c0cefb-b0e7-4848-9749-d3e2ab1b28b3.png)

Search executed from H2 to show that the subject has indeed been deleted from the database:
![Screen Shot 2022-02-18 at 5 32 35 PM](https://user-images.githubusercontent.com/24759371/154780779-9afd91b6-0b6e-4fc7-ac2d-6fc771d8869d.png)

Unit tests / coverage:
![Screen Shot 2022-02-18 at 5 30 13 PM](https://user-images.githubusercontent.com/24759371/154780786-bee05b17-f419-4a35-96d7-22ac561a9e7d.png)

Mutation testing:
![Screen Shot 2022-02-21 at 11 52 26 AM](https://user-images.githubusercontent.com/24759371/155018571-2b1f6e86-514f-4e2a-914d-5655adf8152c.png)

