### PR TITLE
UCSBSubjects Storybook

### DIFF
--- a/frontend/src/stories/components/UCSBSubjects/UCSBSubjectsTable.stories.js
+++ b/frontend/src/stories/components/UCSBSubjects/UCSBSubjectsTable.stories.js
@@ -20,9 +20,9 @@ Empty.args = {
     subjects: []
 };
 
-export const ThreeDates = Template.bind({});
+export const TwoSubjects = Template.bind({});
 
-ThreeDates.args = {
+TwoSubjects.args = {
     subjects: subjectFixtures.twoSubjects
 };
 

--- a/frontend/src/stories/components/UCSBSubjects/UCSBSubjectsTable.stories.js
+++ b/frontend/src/stories/components/UCSBSubjects/UCSBSubjectsTable.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import UCSBSubjectsTable from "main/components/UCSBSubjects/UCSBSubjectsTable";
+import { subjectFixtures } from 'fixtures/ucsbSubjectsFixtures';
+
+export default {
+    title: 'components/UCSBSubjects/UCSBSubjectsTable',
+    component: UCSBSubjectsTable
+};
+
+const Template = (args) => {
+    return (
+        <UCSBSubjectsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    subjects: []
+};
+
+export const ThreeDates = Template.bind({});
+
+ThreeDates.args = {
+    subjects: subjectFixtures.twoSubjects
+};
+
+

--- a/frontend/src/stories/pages/UCSBSubjects/UCSBDatesIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBSubjects/UCSBDatesIndexPage.stories.js
@@ -1,0 +1,17 @@
+
+import React from 'react';
+
+import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage";
+
+export default {
+    title: 'pages/UCSBSubjects/UCSBSubjectsIndexPage',
+    component: UCSBSubjectsIndexPage
+};
+
+const Template = () => <UCSBSubjectsIndexPage />;
+
+export const Default = Template.bind({});
+
+
+
+

--- a/frontend/src/stories/pages/UCSBSubjects/UCSBSubjectsCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBSubjects/UCSBSubjectsCreatePage.stories.js
@@ -1,0 +1,17 @@
+
+import React from 'react';
+
+import UCSBSubjectsCreatePage from "main/pages/UCSBSubjects/UCSBSubjectsCreatePage";
+
+export default {
+    title: 'pages/UCSBSubjects/UCSBSubjectsCreatePage',
+    component: UCSBSubjectsCreatePage
+};
+
+const Template = () => <UCSBSubjectsCreatePage />;
+
+export const Default = Template.bind({});
+
+
+
+


### PR DESCRIPTION
# Overview

Added storybook entries for UCSBSubjects components and pages

# Details

UCSBSubjects Table Component (empty):
<img width="1280" alt="Screen Shot 2022-02-22 at 5 46 36 PM" src="https://user-images.githubusercontent.com/24759371/155249211-15abf954-b842-40d4-a860-070825ed325f.png">

UCSBSubjects Table Component (two subjects):
<img width="1280" alt="Screen Shot 2022-02-22 at 5 46 44 PM" src="https://user-images.githubusercontent.com/24759371/155249225-4b207ff2-d71c-4009-b89c-9fda5e6f779d.png">

UCSBSubjectsIndexPage:
<img width="1280" alt="Screen Shot 2022-02-22 at 5 35 19 PM" src="https://user-images.githubusercontent.com/24759371/155249262-afa343a0-3180-49fe-9e71-0df81325c8df.png">

UCSBSubjectsCreatePage (placeholder):
<img width="1279" alt="Screen Shot 2022-02-22 at 5 35 32 PM" src="https://user-images.githubusercontent.com/24759371/155249297-4e1fbc0f-5d37-455e-8f37-f5af34fb9c9e.png">

